### PR TITLE
Feature/change jdk

### DIFF
--- a/services/hello-service/Dockerfile
+++ b/services/hello-service/Dockerfile
@@ -13,8 +13,9 @@ RUN mvn clean package -DskipTests
 # Runtime stage
 FROM amazoncorretto:17-al2023-jdk
 WORKDIR /app
-# Install shadow-utils (provides groupadd/useradd) and curl for healthcheck
-RUN yum update -y && yum install -y shadow-utils curl && yum clean all
+# Install shadow-utils (provides groupadd/useradd)
+# Note: curl-minimal is already installed for healthcheck
+RUN yum update -y && yum install -y shadow-utils && yum clean all
 # Add a non-root user
 RUN groupadd -r spring && useradd -r -g spring spring
 USER spring:spring

--- a/services/hello-service/Dockerfile
+++ b/services/hello-service/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM maven:3.8-openjdk-17 AS builder
+FROM maven:3.8-amazoncorretto-17 AS builder
 WORKDIR /app
 # Copy pom.xml to download dependencies
 COPY pom.xml .
@@ -11,12 +11,12 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 
 # Runtime stage
-FROM openjdk:17-slim
+FROM amazoncorretto:17-al2023-jdk
 WORKDIR /app
 # Add a non-root user
 RUN groupadd -r spring && useradd -r -g spring spring
 # Install curl for healthcheck
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN yum update -y && yum install -y curl && yum clean all
 USER spring:spring
 # Copy the JAR file from the build stage
 COPY --from=builder /app/target/*.jar app.jar

--- a/services/hello-service/Dockerfile
+++ b/services/hello-service/Dockerfile
@@ -13,10 +13,10 @@ RUN mvn clean package -DskipTests
 # Runtime stage
 FROM amazoncorretto:17-al2023-jdk
 WORKDIR /app
+# Install shadow-utils (provides groupadd/useradd) and curl for healthcheck
+RUN yum update -y && yum install -y shadow-utils curl && yum clean all
 # Add a non-root user
 RUN groupadd -r spring && useradd -r -g spring spring
-# Install curl for healthcheck
-RUN yum update -y && yum install -y curl && yum clean all
 USER spring:spring
 # Copy the JAR file from the build stage
 COPY --from=builder /app/target/*.jar app.jar

--- a/services/hello-service/README.md
+++ b/services/hello-service/README.md
@@ -55,7 +55,7 @@ For the simplest development experience, use VS Code with Dev Containers:
 
 3. Create `.devcontainer/Dockerfile` (optimized for development):
 ```dockerfile
-FROM maven:3.8-openjdk-17
+FROM maven:3.8-amazoncorretto-17
 
 # Create a non-root user
 RUN groupadd -r spring && useradd -r -g spring spring

--- a/services/hello-service/docs/ARCHITECTURE.md
+++ b/services/hello-service/docs/ARCHITECTURE.md
@@ -162,7 +162,7 @@ OpenAPI (Swagger) provides automatic API documentation:
 
 The application is containerized using Docker:
 - Multi-stage build for optimization
-- Base image: Eclipse Temurin JRE 17 Alpine
+- Base image: Amazon Corretto 17 JDK on Amazon Linux 2023
 - Health checks configured
 - JVM optimized for containerized environments
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrate hello-service Docker build/runtime and docs from OpenJDK/Temurin to Amazon Corretto 17 on AL2023, adding required packages for user management.
> 
> - **Containerization**:
>   - Switch builder image to `maven:3.8-amazoncorretto-17` and runtime to `amazoncorretto:17-al2023-jdk` in `services/hello-service/Dockerfile`.
>   - Replace `apt-get` with `yum`; install `shadow-utils`; rely on preinstalled `curl-minimal`; keep non-root `spring` user and healthcheck.
> - **Docs**:
>   - Update devcontainer base image in `services/hello-service/README.md` to `maven:3.8-amazoncorretto-17`.
>   - Update `services/hello-service/docs/ARCHITECTURE.md` to reflect Amazon Corretto 17 JDK on Amazon Linux 2023 as the base image.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 605ee351d6f46e747d40f95656669e7dcec1f124. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->