### PR TITLE
Add service-a and service-b for HTTP 502/503/504 demo

### DIFF
--- a/services/DEMO-HANDBOOK.md
+++ b/services/DEMO-HANDBOOK.md
@@ -1,0 +1,549 @@
+# HTTP 502/503/504 Demo — Handbook
+
+## What Was Built
+
+Two Spring Boot microservices in `services/`:
+
+| Service | Port | Role |
+|---------|------|------|
+| **service-b** | 8082 | Backend — responds immediately or with a configurable delay |
+| **service-a** | 8081 | Gateway — calls service-b via HTTP client, returns 502/503/504 on failure |
+
+---
+
+## Part 1 — Initial Setup (one-time)
+
+### 1.1 Install Colima (Docker Desktop replacement)
+
+```bash
+brew install colima docker docker-compose
+```
+
+Register docker-compose as a Docker plugin:
+
+```bash
+mkdir -p ~/.docker
+cat > ~/.docker/config.json <<'EOF'
+{
+  "cliPluginsExtraDirs": [
+    "/opt/homebrew/lib/docker/cli-plugins"
+  ]
+}
+EOF
+```
+
+### 1.2 Start Colima
+
+```bash
+colima start --cpu 2 --memory 4
+```
+
+You only need to do this once per reboot. To stop Colima when done:
+
+```bash
+colima stop
+```
+
+---
+
+## Part 2 — Start the Services
+
+```bash
+cd services/
+
+# First time: builds Docker images (~5 min — downloads Maven + JDK base images)
+docker compose up --build -d
+
+# Subsequent times: reuses cached layers (much faster)
+docker compose up -d
+```
+
+Wait for both containers to become healthy:
+
+```bash
+docker compose ps
+```
+
+Both should show `(healthy)` before running any demo (~30 seconds after start).
+
+---
+
+## Part 3 — Verify Everything Works
+
+```bash
+# service-a health
+curl http://localhost:8081/actuator/health
+
+# service-b health
+curl http://localhost:8082/actuator/health
+
+# Read active configuration — do this first before any demo
+curl http://localhost:8081/api/config
+```
+
+The `/api/config` response shows the active timeouts and explains which curl command triggers each error. Key values:
+
+| Setting | Default | Meaning |
+|---------|---------|---------|
+| `readTimeoutMs` | 5000 | service-a waits 5s for a response before giving up |
+| `keepAlive.idleTimeoutMs` | 30000 | service-a holds connections open for 30s |
+| `automaticRetries` | DISABLED | stale connections surface as 502, not silently retried |
+
+---
+
+## Part 4 — Happy Path (200 OK)
+
+```bash
+curl http://localhost:8081/api/call
+```
+
+service-a calls service-b `/api/data`, gets an immediate response, and proxies it back:
+
+```json
+{
+  "status": "ok",
+  "upstream": "http://service-b:8082/api/data",
+  "upstreamData": {
+    "status": "ok",
+    "message": "Data returned immediately",
+    "delayMs": 0,
+    "serverInstance": "abc123def456"
+  },
+  "elapsedMs": 45
+}
+```
+
+---
+
+## Part 5 — Scenario 1: 504 Gateway Timeout
+
+**What happens:** service-b sleeps longer than service-a's read timeout.
+Apache HttpClient raises `SocketTimeoutException` after 5000ms → service-a returns 504.
+
+### Trigger
+
+```bash
+# Always quote the URL in zsh — ? is a glob character
+curl -v "http://localhost:8081/api/call-slow?delayMs=10000"
+```
+
+Hangs for exactly 5 seconds, then returns:
+
+```json
+{
+  "httpStatus": 504,
+  "error": "504 Gateway Timeout",
+  "scenario": "TIMEOUT",
+  "message": "service-b did not respond within 5000ms..."
+}
+```
+
+### Try the boundary
+
+```bash
+# 4900ms — just under the 5000ms timeout → 200 OK
+curl "http://localhost:8081/api/call-slow?delayMs=4900"
+
+# 5100ms — just over → 504
+curl "http://localhost:8081/api/call-slow?delayMs=5100"
+```
+
+### Lower the timeout without rebuilding
+
+```bash
+docker compose stop service-a
+
+docker compose run --rm \
+  -e APP_HTTP_CLIENT_READ_TIMEOUT_MS=2000 \
+  -p 8081:8081 \
+  service-a
+```
+
+Now a 3-second delay triggers 504:
+
+```bash
+curl "http://localhost:8081/api/call-slow?delayMs=3000"
+```
+
+Restore: press `Ctrl+C`, then `docker compose up -d service-a`
+
+---
+
+## Part 6 — Scenario 2: 503 Service Unavailable
+
+**What happens:** service-a cannot reach service-b at all (connection refused / host unreachable) → 503.
+
+### Method A — Stop service-b
+
+```bash
+docker compose stop service-b
+
+curl "http://localhost:8081/api/call"
+```
+
+Expected:
+
+```json
+{
+  "httpStatus": 503,
+  "error": "503 Service Unavailable",
+  "scenario": "UNREACHABLE",
+  "message": "Could not establish a connection to service-b..."
+}
+```
+
+Restore:
+
+```bash
+docker compose start service-b
+# Wait ~20 seconds for service-b to be healthy before the next test
+```
+
+### Method B — Wrong base URL (no container stop needed)
+
+```bash
+docker compose stop service-a
+
+docker compose run --rm \
+  -e APP_HTTP_CLIENT_BASE_URL=http://nonexistent-host:9999 \
+  -p 8081:8081 \
+  service-a
+```
+
+In another terminal:
+
+```bash
+curl "http://localhost:8081/api/call"
+```
+
+Returns 503 immediately — DNS lookup fails, TCP connection is never attempted.
+
+Restore: `Ctrl+C`, then `docker compose up -d service-a`
+
+---
+
+## Part 7 — Scenario 3: 502 Bad Gateway (Stale Keep-Alive)
+
+**What happens:** This is the subtlest scenario. Three settings work together to create it:
+
+1. service-b closes idle TCP connections after **5 seconds** (`server.tomcat.keep-alive-timeout: 5000`)
+2. service-a's pool is told to hold connections for **30 seconds** (`keep-alive.idle-timeout-ms: 30000`) — and critically, it **ignores** service-b's `Keep-Alive: timeout=5` response header (otherwise the pool would expire the connection correctly and open a fresh one, silently returning 200)
+3. Automatic retries are **disabled** — so when service-a tries to write on the dead socket and gets `NoHttpResponseException`, it surfaces as 502 instead of being silently retried on a fresh connection
+
+### Step-by-step
+
+**Step 1 — Warm the connection pool and note the `clientPort`:**
+
+```bash
+curl "http://localhost:8081/api/call"
+```
+
+Look for `clientPort` inside `upstreamData`. This is the ephemeral TCP port service-a used for the outgoing connection. Same port = same TCP connection. Different port = new connection.
+
+**Step 2 — Call again immediately and confirm the port is unchanged (connection reused):**
+
+```bash
+curl "http://localhost:8081/api/call"
+```
+
+`clientPort` should be identical to Step 1 — Apache HttpClient pulled the same socket from its pool.
+
+**Step 3 — Wait 6 seconds** (service-b closes the idle connection at 5s):
+
+```bash
+sleep 6
+```
+
+**Step 4 — Call again** (service-a tries to reuse the now-stale connection):
+
+```bash
+curl -v "http://localhost:8081/api/call"
+```
+
+Expected:
+
+```json
+{
+  "httpStatus": 502,
+  "error": "502 Bad Gateway",
+  "scenario": "STALE_CONNECTION",
+  "message": "service-b closed the keep-alive connection before service-a could reuse it..."
+}
+```
+
+### The "fix" — teaching moment
+
+The standard production fix is to re-enable automatic retries:
+
+1. Edit `service-a/src/main/java/com/sbxservice/servicea/config/HttpClientConfig.java`
+2. Comment out `.disableAutomaticRetries()` (around line 80)
+3. Rebuild: `docker compose up --build -d service-a`
+4. Repeat steps 1–3 above → you now get **200** instead of 502
+
+Apache HttpClient silently retried on a fresh connection. The 502 is only visible because retries are intentionally disabled in this demo.
+
+### Tweak keep-alive to make 502 easier or harder to trigger
+
+| Change | Effect |
+|--------|--------|
+| Raise `APP_HTTP_CLIENT_KEEP_ALIVE_IDLE_TIMEOUT_MS` to e.g. 60000 | Pool holds longer → 502 easier to trigger |
+| Lower it below 5000 | Pool evicts before service-b does → 502 never happens |
+| Set `APP_HTTP_CLIENT_KEEP_ALIVE_ENABLED=false` | One connection per request → no stale connections → no 502 |
+
+---
+
+## Part 8 — Swagger UI
+
+Both services expose Swagger UI for interactive exploration:
+
+| URL | Service |
+|-----|---------|
+| `http://localhost:8081/swagger-ui.html` | service-a — gateway endpoints |
+| `http://localhost:8082/swagger-ui.html` | service-b — backend endpoints |
+
+You can call service-b's `/api/slow` endpoint directly from its Swagger UI to observe the delay without going through service-a.
+
+---
+
+## Part 9 — Useful Commands
+
+```bash
+# Live logs from both services
+docker compose logs -f
+
+# Logs from service-a only
+docker compose logs -f service-a
+
+# Check service-b keep-alive settings
+curl http://localhost:8082/api/status
+
+# Restart all containers
+docker compose restart
+
+# Stop all containers (keeps images)
+docker compose down
+
+# Rebuild and restart a single service
+docker compose up --build -d service-a
+```
+
+---
+
+## Part 10 — Configuration Reference
+
+All `app.http-client.*` values can be overridden at runtime via environment variables — no rebuild needed.
+
+| application.yml key | Environment variable | Default | What it controls | Error when exceeded |
+|---------------------|---------------------|---------|-----------------|---------------------|
+| `app.http-client.base-url` | `APP_HTTP_CLIENT_BASE_URL` | `http://service-b:8082` | Where service-a sends requests | 503 if host is unreachable |
+| `app.http-client.connect-timeout-ms` | `APP_HTTP_CLIENT_CONNECT_TIMEOUT_MS` | `3000` | TCP handshake timeout (see below) | **504** Gateway Timeout |
+| `app.http-client.read-timeout-ms` | `APP_HTTP_CLIENT_READ_TIMEOUT_MS` | `5000` | Time to wait for first response byte after connected | **504** Gateway Timeout |
+| `app.http-client.pool.max-total` | `APP_HTTP_CLIENT_POOL_MAX_TOTAL` | `50` | Max connections across all routes | **503** when pool exhausted and request-timeout fires |
+| `app.http-client.keep-alive.enabled` | `APP_HTTP_CLIENT_KEEP_ALIVE_ENABLED` | `true` | Toggle keep-alive on/off | — |
+| `app.http-client.keep-alive.idle-timeout-ms` | `APP_HTTP_CLIENT_KEEP_ALIVE_IDLE_TIMEOUT_MS` | `30000` | How long idle connections stay in pool | **502** when set longer than server's keep-alive timeout |
+
+### What happens when `connect-timeout-ms` is exceeded (TCP handshake timeout)
+
+`connect-timeout-ms` controls how long service-a waits for the **TCP 3-way handshake** to complete — the `SYN → SYN-ACK → ACK` exchange that happens before any HTTP byte is sent.
+
+```
+service-a                        service-b
+    |  ── SYN ──────────────────→  |
+    |  ← SYN-ACK ────────────────  |   ← must arrive within connect-timeout-ms
+    |  ── ACK ──────────────────→  |
+    |                              |   ← HTTP request starts only after this
+```
+
+When `connect-timeout-ms` fires before `SYN-ACK` arrives, Apache HttpClient 5 throws `ConnectTimeoutException`, which extends `java.net.SocketTimeoutException`. Our `GlobalExceptionHandler` catches `SocketTimeoutException` and returns **504 Gateway Timeout**.
+
+**Why 504 and not 503?**
+
+Semantically, a connect timeout feels like "service unavailable" — but the HTTP spec defines 503 as "the server is temporarily unable to handle the request" (implying the server was reached) and 504 as "the gateway did not receive a timely response from an upstream server". A connect timeout fits 504 more precisely: service-a (the gateway) did not receive any response from service-b within the allowed time.
+
+**Common causes of connect timeout in production:**
+
+| Cause | What is happening |
+|-------|------------------|
+| Upstream is overloaded | TCP backlog is full — `SYN` packets are queued or dropped |
+| Wrong host / port | The packet is routed into a black hole — no `RST`, just silence |
+| Firewall drops SYN | Same effect — the handshake never completes |
+| Network partition | Packets between the two services are lost |
+
+**Contrast with connection refused (503):**
+If the upstream is completely down, the OS returns an immediate `RST` instead of silence — the handshake fails instantly rather than timing out. That throws `ConnectException` (not `SocketTimeoutException`), which our handler maps to **503**.
+
+```
+connect-timeout fires (silence)  → ConnectTimeoutException → SocketTimeoutException → 504
+connection refused   (immediate) → ConnectException        → SocketException        → 503
+```
+
+service-b's keep-alive timeout lives in `service-b/src/main/resources/application.yml`:
+
+```yaml
+server:
+  tomcat:
+    keep-alive-timeout: 5000   # milliseconds — change requires rebuild
+```
+
+---
+
+## Quick Reference
+
+```bash
+# Start
+cd services && docker compose up -d
+
+# Health check
+curl http://localhost:8081/actuator/health
+
+# Read config
+curl http://localhost:8081/api/config
+
+# 200 OK
+curl "http://localhost:8081/api/call"
+
+# 504 Gateway Timeout
+curl "http://localhost:8081/api/call-slow?delayMs=10000"
+
+# 503 Service Unavailable
+docker compose stop service-b
+curl "http://localhost:8081/api/call"
+docker compose start service-b
+
+# 502 Bad Gateway
+curl "http://localhost:8081/api/call" && sleep 6 && curl "http://localhost:8081/api/call"
+
+# Stop all
+docker compose down
+```
+
+---
+
+## Part 11 — How to Prevent 502 Bad Gateway in Production
+
+The demo deliberately breaks three rules to make the 502 visible. Each broken rule is a real-world best practice. Here they are, most impactful first.
+
+---
+
+### Rule 1 — Client idle timeout must be shorter than server keep-alive timeout
+
+This is the fundamental rule. A 502 from a stale connection happens because **the server closed the TCP connection before the client stopped using it**.
+
+```
+Server keep-alive timeout:  5s   ← service-b in the demo
+Client pool idle timeout:  30s   ← service-a in the demo  (WRONG: longer than server)
+```
+
+The client pool held a connection it thought was valid for 30s, but the server closed it at 5s.
+
+**The fix:** Always set the client's idle timeout shorter than the server's keep-alive timeout. A safe margin is 20–30%:
+
+```yaml
+# service-b (server) closes idle connections after 60s (production default)
+server:
+  tomcat:
+    keep-alive-timeout: 60000   # 60s
+
+# service-a (client) should retire connections before the server does
+app:
+  http-client:
+    keep-alive:
+      idle-timeout-ms: 45000    # 45s — 25% shorter than server's 60s ✓
+```
+
+In our demo, the equivalent correct setting would be `idle-timeout-ms: 3000` (shorter than service-b's 5s). With that, the pool would retire the connection cleanly and open a fresh one — never hitting a stale socket.
+
+---
+
+### Rule 2 — Honour the server's `Keep-Alive: timeout=N` response header
+
+When a server sends `Keep-Alive: timeout=5` in its HTTP response, it is explicitly advertising how long it will keep the connection open. A well-behaved client reads this and schedules connection expiry accordingly.
+
+In our demo, we **deliberately ignored** this header so the demo would work. The keep-alive strategy in `HttpClientConfig` was changed to:
+
+```java
+// DEMO ONLY — intentionally ignores server's Keep-Alive header
+return TimeValue.ofMilliseconds(props.getKeepAlive().getIdleTimeoutMs()); // always 30s
+```
+
+In production, restore the header-aware strategy:
+
+```java
+// PRODUCTION — honour the server's advertised timeout
+for (Header header : response.getHeaders("Keep-Alive")) {
+    for (String part : header.getValue().split(",")) {
+        if (part.trim().toLowerCase().startsWith("timeout=")) {
+            long secs = Long.parseLong(part.trim().substring(8));
+            return TimeValue.of(secs, TimeUnit.SECONDS);
+        }
+    }
+}
+return TimeValue.ofMilliseconds(props.getKeepAlive().getIdleTimeoutMs()); // fallback
+```
+
+This means the client always retires connections at or before the server's stated deadline — the stale-connection window closes to near zero.
+
+---
+
+### Rule 3 — Enable automatic retries for idempotent requests
+
+Even with correct timeout settings, a race condition can still occur: the server closes the connection at exactly the moment the client sends a request. This is called a **race close** and cannot be eliminated — it is an inherent property of HTTP/1.1 keep-alive.
+
+The standard defence is a **single automatic retry on `NoHttpResponseException`** for idempotent methods (GET, HEAD, PUT, DELETE). Apache HttpClient 5 does this by default. We disabled it in the demo specifically to expose the raw 502.
+
+In production, **do not call `.disableAutomaticRetries()`**:
+
+```java
+return HttpClients.custom()
+        .setConnectionManager(connectionManager)
+        .setDefaultRequestConfig(requestConfig)
+        .setKeepAliveStrategy(keepAliveStrategy)
+        // .disableAutomaticRetries()  ← remove this line in production
+        .build();
+```
+
+With retries enabled, the race-close scenario is transparently handled: HC5 retries once on a fresh connection and the caller sees a normal 200.
+
+> **Why retries are safe for GET but not always for POST:** Retrying a GET returns the same data — no side effects. Retrying a POST might create a duplicate record. For non-idempotent methods, disable retries and handle 502 at the caller level (e.g. with a circuit breaker) instead.
+
+---
+
+### Rule 4 — Enable connection validation before reuse
+
+In our demo we set `validateAfterInactivity(-1)` to disable HC5's built-in connection health check. In production, leave it at the default (2 seconds) or set it explicitly:
+
+```java
+cm.setValidateAfterInactivity(TimeValue.ofSeconds(2));
+```
+
+With this enabled, HC5 silently checks whether a connection is still alive before sending a request on it, if the connection has been idle for more than 2 seconds. If the check fails, it opens a fresh connection. This adds a tiny overhead (one TCP probe) but eliminates most stale-connection 502s without needing a retry.
+
+---
+
+### Rule 5 — Set a hard connection TTL
+
+Even a connection with a perfect idle timeout can become stale if it has been open for a very long time (servers can be restarted, load balancers can reset long-lived connections silently). Set a maximum connection lifetime:
+
+```java
+PoolingHttpClientConnectionManager cm = PoolingHttpClientConnectionManagerBuilder.create()
+        .setConnectionTimeToLive(TimeValue.ofMinutes(5))   // retire all connections after 5 min
+        .build();
+```
+
+This limits how long any single TCP connection lives regardless of activity, giving you a hard safety net against all forms of silent connection closure.
+
+---
+
+### Summary Table
+
+| Rule | What we broke in the demo | Production setting |
+|------|--------------------------|-------------------|
+| Client idle timeout < server keep-alive | `idle-timeout-ms: 30000` > server's 5s | Set client timeout shorter than server's |
+| Honour server's `Keep-Alive` header | Ignored the header entirely | Parse and respect `Keep-Alive: timeout=N` |
+| Enable automatic retries | `.disableAutomaticRetries()` | Remove that call (default = retry once) |
+| Enable connection validation | `validateAfterInactivity(-1)` | Default 2s, or set explicitly |
+| Set connection TTL | Not set | `setConnectionTimeToLive(5 minutes)` |
+
+Applying Rules 1 + 2 eliminates the problem by design.
+Rules 3 + 4 are defence-in-depth for the unavoidable race-close edge case.
+Rule 5 is a long-term safety net against anything else that silently closes TCP connections (NAT timeouts, load balancer resets, server restarts).

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -1,0 +1,85 @@
+version: '3.8'
+
+# Shared docker-compose — runs service-a + service-b together for the 502/503/504 demo.
+#
+# Usage:
+#   cd services/
+#   docker-compose up --build
+#
+# Demo scenarios (after both containers are healthy):
+#
+#   Happy path:
+#     curl http://localhost:8081/api/call
+#
+#   Check active config first:
+#     curl http://localhost:8081/api/config
+#
+#   504 Gateway Timeout  — service-b sleeps 10s, service-a read-timeout is 5s:
+#     curl -v http://localhost:8081/api/call-slow?delayMs=10000
+#
+#   503 Service Unavailable  — stop service-b:
+#     docker stop service-b
+#     curl -v http://localhost:8081/api/call
+#     docker start service-b
+#
+#   502 Bad Gateway  — stale keep-alive connection:
+#     curl http://localhost:8081/api/call   # warms the connection pool
+#     sleep 6                               # service-b closes keep-alive after 5s
+#     curl -v http://localhost:8081/api/call  # service-a reuses stale connection → 502
+#
+# Environment overrides (no rebuild needed):
+#   Lower read timeout to make 504 easier to trigger:
+#     APP_HTTP_CLIENT_READ_TIMEOUT_MS=2000 docker-compose up service-a service-b
+#
+#   Point service-a at a non-existent host to trigger 503 without stopping service-b:
+#     APP_HTTP_CLIENT_BASE_URL=http://nonexistent:9999 docker-compose up service-a service-b
+
+services:
+
+  service-b:
+    build:
+      context: ./service-b
+      dockerfile: Dockerfile
+    container_name: service-b
+    ports:
+      - "8082:8082"
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - JAVA_OPTS=-Xmx512m -Xms256m
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8082/actuator/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 20s
+    networks:
+      - demo-network
+
+  service-a:
+    build:
+      context: ./service-a
+      dockerfile: Dockerfile
+    container_name: service-a
+    ports:
+      - "8081:8081"
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - JAVA_OPTS=-Xmx512m -Xms256m
+      # Docker's internal DNS resolves 'service-b' to the container's IP on demo-network.
+      # Override with APP_HTTP_CLIENT_BASE_URL to point at a different host.
+      - APP_HTTP_CLIENT_BASE_URL=http://service-b:8082
+    depends_on:
+      service-b:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 20s
+    networks:
+      - demo-network
+
+networks:
+  demo-network:
+    driver: bridge

--- a/services/service-a/Dockerfile
+++ b/services/service-a/Dockerfile
@@ -1,0 +1,24 @@
+# Build stage
+FROM maven:3.8-amazoncorretto-17 AS builder
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# Runtime stage
+FROM amazoncorretto:17-al2023-jdk
+WORKDIR /app
+RUN yum update -y && yum install -y shadow-utils && yum clean all
+RUN groupadd -r spring && useradd -r -g spring spring
+USER spring:spring
+COPY --from=builder /app/target/*.jar app.jar
+EXPOSE 8081
+HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
+  CMD curl -f http://localhost:8081/actuator/health || exit 1
+ENTRYPOINT ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "-Djava.security.egd=file:/dev/./urandom", \
+  "-jar", \
+  "app.jar"]

--- a/services/service-a/README.md
+++ b/services/service-a/README.md
@@ -1,0 +1,384 @@
+# service-a — Gateway Service
+
+service-a is a Spring Boot 3.2 gateway that accepts HTTP requests from clients and proxies them to [service-b](../service-b/README.md) using Apache HttpClient 5. Its purpose is to demonstrate how **502 Bad Gateway**, **503 Service Unavailable**, and **504 Gateway Timeout** errors are produced and how they can be prevented.
+
+---
+
+## Architecture
+
+```
+Client
+  │
+  ▼
+service-a :8081          (this service)
+  │   RestClient + Apache HttpClient 5
+  │   configurable: connect timeout, read timeout, keep-alive, pool size
+  ▼
+service-b :8082          (see ../service-b)
+  │   endpoints: /api/data (fast), /api/slow (configurable delay)
+  │   Tomcat keep-alive-timeout: 5s
+```
+
+The design intentionally creates a **mismatch** between the client and server:
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| service-b keep-alive-timeout | 5s | Server closes idle connections after 5s |
+| service-a pool idle-timeout | 30s | Client holds connections for 30s → stale connection → 502 |
+| service-a read-timeout | 5s | Client waits 5s for response → exceeded by slow endpoint → 504 |
+
+---
+
+## Quick Start
+
+```bash
+# From services/ directory
+docker compose up --build -d
+curl http://localhost:8081/api/config   # see active settings
+curl http://localhost:8081/api/call     # happy path → 200
+```
+
+See [DEMO-HANDBOOK.md](../DEMO-HANDBOOK.md) for full demo instructions.
+
+---
+
+## Key Source Files
+
+### 1. `HttpClientProperties.java` — configuration model
+
+```
+src/main/java/com/sbxservice/servicea/config/HttpClientProperties.java
+```
+
+A `@ConfigurationProperties` class that binds `application.yml` values and makes them injectable. Every timeout in the system flows through this class.
+
+```java
+@ConfigurationProperties(prefix = "app.http-client")
+public class HttpClientProperties {
+    private String baseUrl;
+    private int connectTimeoutMs;   // TCP handshake timeout
+    private int readTimeoutMs;      // response wait timeout
+    private Pool pool;
+    private KeepAlive keepAlive;
+}
+```
+
+**Why this matters:** All timeouts are externalised — no rebuild is needed to change them. You can override any value with an environment variable at container start (e.g. `APP_HTTP_CLIENT_READ_TIMEOUT_MS=2000`). This is what makes the demo configurable without touching code.
+
+---
+
+### 2. `HttpClientConfig.java` — the HTTP client bean
+
+```
+src/main/java/com/sbxservice/servicea/config/HttpClientConfig.java
+```
+
+This is the most important file. It wires Apache HttpClient 5 into a Spring `RestClient` bean with three deliberate decisions that make the error scenarios reproducible.
+
+#### Decision 1 — Two layers of timeout
+
+```java
+// Layer 1: per-connection defaults in the pool
+ConnectionConfig connConfig = ConnectionConfig.custom()
+    .setConnectTimeout(Timeout.ofMilliseconds(props.getConnectTimeoutMs()))
+    .setSocketTimeout(Timeout.ofMilliseconds(props.getReadTimeoutMs()))
+    .build();
+
+// Layer 2: per-request override (takes precedence)
+RequestConfig requestConfig = RequestConfig.custom()
+    .setResponseTimeout(Timeout.ofMilliseconds(props.getReadTimeoutMs()))
+    .build();
+```
+
+HC5 applies the per-request config over the per-connection default. Both are set to the same value here for clarity, but in production they can differ (e.g. a longer default with shorter overrides per endpoint).
+
+#### Decision 2 — Keep-alive strategy ignores the server's header (demo only)
+
+```java
+var keepAliveStrategy = (ConnectionKeepAliveStrategy) (response, context) -> {
+    if (!props.getKeepAlive().isEnabled()) {
+        return TimeValue.ZERO_MILLISECONDS;
+    }
+    // Intentionally ignores Keep-Alive: timeout=5 from service-b.
+    // If we honoured it, the pool would expire the connection correctly
+    // and open a fresh one — bypassing the 502 scenario entirely.
+    return TimeValue.ofMilliseconds(props.getKeepAlive().getIdleTimeoutMs()); // 30s
+};
+```
+
+In production, you should parse the `Keep-Alive: timeout=N` header and return that value — see Part 11 of the handbook.
+
+#### Decision 3 — Disable automatic retries and connection validation (demo only)
+
+```java
+// Disable pre-reuse validation: HC5 normally checks if a pooled connection
+// is still alive after 2s of inactivity. Disabling this means it blindly
+// sends on the stale socket → NoHttpResponseException → 502.
+cm.setValidateAfterInactivity(TimeValue.ofMilliseconds(-1));
+
+// Disable auto-retry: HC5 normally retries once on a fresh connection when
+// it gets NoHttpResponseException on an idempotent request. Disabling this
+// lets the 502 surface to the caller instead of being silently resolved.
+HttpClients.custom()
+    .disableAutomaticRetries()
+    ...
+```
+
+Both of these should be left at their defaults in production.
+
+---
+
+### 3. `GlobalExceptionHandler.java` — maps HC5 exceptions to HTTP status codes
+
+```
+src/main/java/com/sbxservice/servicea/exception/GlobalExceptionHandler.java
+```
+
+`RestClient` wraps all I/O failures in `ResourceAccessException`. The handler unwraps the root cause and maps it:
+
+```java
+@ExceptionHandler(ResourceAccessException.class)
+public ResponseEntity<ErrorResponse> handleResourceAccess(ResourceAccessException ex) {
+    Throwable cause = ex.getCause();
+
+    if (cause instanceof SocketTimeoutException)
+        → 504 Gateway Timeout       // read timeout OR connect timeout (ConnectTimeoutException extends SocketTimeoutException)
+
+    if (cause instanceof ConnectException || cause instanceof SocketException)
+        → 503 Service Unavailable   // connection refused, host unreachable, system error
+
+    if (cause instanceof NoHttpResponseException || message contains "connection reset")
+        → 502 Bad Gateway           // stale keep-alive connection reused
+}
+```
+
+**The exception hierarchy is the critical detail:**
+
+```
+java.io.IOException
+ └── java.net.SocketException
+      └── java.net.SocketTimeoutException          → 504
+           └── ConnectTimeoutException (HC5)        → 504  ← connect timeout, NOT 503
+      └── java.net.ConnectException                 → 503  ← connection refused
+ └── org.apache.hc.core5.http.NoHttpResponseException → 502  ← stale connection
+```
+
+Notice that a **TCP connect timeout** (SYN sent, no SYN-ACK) returns **504**, not 503, because `ConnectTimeoutException` extends `SocketTimeoutException`. A **connection refused** (immediate RST) returns **503** because it throws `ConnectException`. See Part 10 of the handbook for details.
+
+---
+
+### 4. `application.yml` — the mismatch that enables the 502 demo
+
+```
+src/main/resources/application.yml
+```
+
+```yaml
+app:
+  http-client:
+    read-timeout-ms: 5000       # 504 fires when service-b delay > this
+    keep-alive:
+      idle-timeout-ms: 30000    # 30s pool timeout > service-b's 5s Tomcat timeout
+                                # this mismatch is what makes the 502 reproducible
+```
+
+The 6-second gap between `idle-timeout-ms: 30000` and service-b's `keep-alive-timeout: 5000` is the window in which the 502 lives. If you set `idle-timeout-ms` to anything ≤ 5000, the 502 disappears — the pool retires the connection before service-b closes it.
+
+---
+
+## How Apache HttpClient 5 Decides: Reuse vs. New Connection
+
+Every outgoing request goes through this decision tree inside `PoolingHttpClientConnectionManager`:
+
+```
+Request arrives
+      │
+      ▼
+Is there an available connection for this route (host:port) in the pool?
+      │
+  YES ─────────────────────────────────────────────────────────────────┐
+      │                                                                 │
+      ▼                                                                 │
+Has the connection exceeded connectionTimeToLive?                       │
+      │                                                                 │
+  YES → discard, try pool again                                        │
+  NO  ──────────────────────────────────────────────────────────────── ▼
+      │                                                      Has it been idle longer than
+      │                                                      validateAfterInactivity?
+      │                                                                 │
+      │                                                    YES → send TCP probe
+      │                                                         alive? → REUSE
+      │                                                         dead?  → discard, try pool again
+      │                                                    NO  → REUSE immediately (no probe)
+      │
+  NO (pool empty or all connections in use)
+      │
+      ▼
+Has maxPerRoute been reached?
+      │
+  NO  → create a NEW connection (OS assigns a new ephemeral port)
+  YES → wait up to connectionRequestTimeout for a slot
+         timeout fires → ConnectionRequestTimeoutException → 503
+```
+
+### The role of `validateAfterInactivity`
+
+This is the setting that determines whether HC5 **probes** a connection before reusing it:
+
+```java
+// In this demo: disabled — HC5 blindly reuses without probing (enables 502 demo)
+cm.setValidateAfterInactivity(TimeValue.ofMilliseconds(-1));
+
+// In production: probe connections idle for more than 2s
+cm.setValidateAfterInactivity(TimeValue.ofSeconds(2));
+```
+
+With probing enabled, HC5 sends a minimal TCP check on the socket. If the socket is dead (service-b sent `FIN`), the probe fails immediately, HC5 discards that connection and opens a fresh one — returning 200 instead of 502.
+
+### The role of the keep-alive strategy
+
+After every successful response, HC5 calls the `ConnectionKeepAliveStrategy` to decide how long to keep the connection in the pool:
+
+```java
+// Returns the TTL for this connection
+TimeValue ttl = keepAliveStrategy.getKeepAliveDuration(response, context);
+
+if (ttl.isZero())     → close connection immediately (no reuse)
+if (ttl.isPositive()  → put back in pool, expire after ttl
+```
+
+In this demo the strategy returns `idleTimeoutMs` (30s) regardless of what service-b advertises. In production it should honour the server's `Keep-Alive: timeout=N` header so the pool retires connections before the server closes them.
+
+### How `clientPort` makes this observable
+
+service-b includes `clientPort` (`HttpServletRequest.getRemotePort()`) in every response — the ephemeral source port of service-a's outgoing TCP socket. Because a reused connection reuses the same socket, the port stays the same:
+
+```bash
+curl http://localhost:8081/api/call   # → clientPort: 57498  (new connection)
+curl http://localhost:8081/api/call   # → clientPort: 57498  (reused — same socket)
+sleep 7
+curl http://localhost:8081/api/call   # → 502                (service-a tried port 57498,
+                                      #                       service-b already closed it)
+```
+
+---
+
+## Pool Borrowing Strategy: How 5 Requests Use 6 Pooled Connections
+
+Suppose the pool has 6 idle connections (p1–p6) for the `service-b:8082` route and 5 requests (r1–r5) arrive.
+
+### Sequential requests (one at a time)
+
+HC5 uses **LIFO** — the most recently returned connection is always picked first:
+
+```
+Pool (stack, top = most recent): [p1, p2, p3, p4, p5, p6]
+
+r1 arrives → borrows p6 (top of stack)   pool: [p1..p5]  leased: {r1=p6}
+r1 done    → returns p6                  pool: [p1..p5, p6]
+
+r2 arrives → borrows p6 again            pool: [p1..p5]  leased: {r2=p6}
+r2 done    → returns p6                  pool: [p1..p5, p6]
+
+r3 → p6 → r4 → p6 → r5 → p6
+```
+
+**All 5 requests reuse p6. p1–p5 are never touched.**
+
+`clientPort` will be the same number for all 5 responses.
+
+LIFO is intentional: keeping one connection "hot" lets p1–p5 sit idle until they exceed `validateAfterInactivity` and get evicted. The pool naturally shrinks to the size actually needed. **Sizing a pool to 50 does not mean 50 connections are open — it means 50 can be open at peak concurrency.**
+
+### Concurrent requests (all in-flight simultaneously)
+
+```
+Pool: [p1, p2, p3, p4, p5, p6]   ← all available
+
+r1 arrives → borrows p6           pool: [p1..p5]
+r2 arrives → borrows p5           pool: [p1..p4]
+r3 arrives → borrows p4           pool: [p1..p3]
+r4 arrives → borrows p3           pool: [p1..p2]
+r5 arrives → borrows p2           pool: [p1]      ← one still available
+```
+
+All 5 complete and return their connections — pool is back to 6.
+
+**Each request gets a different connection. p1 is never used.** Each response shows a different `clientPort`.
+
+### What happens when the pool is exhausted
+
+If a 6th request r6 arrives while r1–r5 are all still in-flight:
+
+```
+Pool: [p1]  ← one left
+
+r6 arrives → borrows p1           pool: []   ← empty
+```
+
+A 7th request r7 now finds the pool empty **and** `maxPerRoute` reached:
+
+```
+r7 arrives → no available connection, maxPerRoute=6 reached
+          → waits up to connectionRequestTimeout (default = connectTimeoutMs = 3s)
+          → timeout fires → ConnectionRequestTimeoutException → 503
+```
+
+### Practical sizing rule
+
+Pool size should match **concurrency**, not total throughput.
+
+| Traffic | Avg response time | Concurrent in-flight | Recommended pool size |
+|---------|-------------------|---------------------|-----------------------|
+| 1000 req/s | 10ms | 1000 × 0.01 = **10** | 12–15 (10 + headroom) |
+| 1000 req/s | 500ms | 1000 × 0.5 = **500** | 550–600 |
+| 100 req/s | 5s | 100 × 5 = **500** | 550–600 |
+
+Formula: `pool size ≥ requests_per_second × avg_response_time_seconds`
+
+With this demo's default `maxPerRoute: 20`, the pool supports up to 20 simultaneous in-flight requests to service-b. For sequential traffic, 1 connection does the work of all 20.
+
+---
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/call` | Proxy to service-b `/api/data` — happy path or 502/503 |
+| `GET` | `/api/call-slow?delayMs=10000` | Proxy to service-b `/api/slow` — triggers 504 |
+| `GET` | `/api/config` | Show current HTTP client settings |
+| `GET` | `/actuator/health` | Health check |
+| `GET` | `/swagger-ui.html` | Interactive API docs |
+
+---
+
+## Error Response Format
+
+All errors return a structured JSON body:
+
+```json
+{
+  "httpStatus": 504,
+  "error": "504 Gateway Timeout",
+  "scenario": "TIMEOUT",
+  "message": "service-b did not respond within 5000ms...",
+  "upstreamUrl": "http://service-b:8082",
+  "timestamp": "2026-06-04T16:00:00Z"
+}
+```
+
+`scenario` is one of: `TIMEOUT`, `UNREACHABLE`, `STALE_CONNECTION`, `UPSTREAM_ERROR`.
+
+---
+
+## Configuration Override (no rebuild)
+
+```bash
+# Lower read timeout to 2s — makes 504 easier to trigger
+docker compose run --rm -e APP_HTTP_CLIENT_READ_TIMEOUT_MS=2000 -p 8081:8081 service-a
+
+# Point at a non-existent host — triggers 503 immediately
+docker compose run --rm -e APP_HTTP_CLIENT_BASE_URL=http://nonexistent:9999 -p 8081:8081 service-a
+
+# Disable keep-alive — prevents 502 stale-connection scenario
+docker compose run --rm -e APP_HTTP_CLIENT_KEEP_ALIVE_ENABLED=false -p 8081:8081 service-a
+```

--- a/services/service-a/docker-compose.yml
+++ b/services/service-a/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  service-a:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: service-a
+    ports:
+      - "8081:8081"
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - JAVA_OPTS=-Xmx512m -Xms256m
+      - APP_HTTP_CLIENT_BASE_URL=http://service-b:8082
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 20s
+    networks:
+      - sbxservice-network
+
+networks:
+  sbxservice-network:
+    driver: bridge

--- a/services/service-a/pom.xml
+++ b/services/service-a/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.3</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.sbxservice</groupId>
+    <artifactId>service-a</artifactId>
+    <version>0.1.0</version>
+    <name>service-a</name>
+    <description>Gateway service that proxies requests to service-b to demonstrate 502/503/504 HTTP errors</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
+        <jacoco.version>0.8.11</jacoco.version>
+        <lombok.version>1.18.30</lombok.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Apache HttpClient 5 — provides fine-grained control over keepalive, timeouts, and connection pooling -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <!-- version managed by spring-boot-starter-parent 3.2.3 -->
+        </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc-openapi.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                    <image>
+                        <name>sbxservice/${project.artifactId}:${project.version}</name>
+                    </image>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/services/service-a/src/main/java/com/sbxservice/servicea/ServiceAApplication.java
+++ b/services/service-a/src/main/java/com/sbxservice/servicea/ServiceAApplication.java
@@ -1,0 +1,15 @@
+package com.sbxservice.servicea;
+
+import com.sbxservice.servicea.config.HttpClientProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@EnableConfigurationProperties(HttpClientProperties.class)
+public class ServiceAApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ServiceAApplication.class, args);
+    }
+}

--- a/services/service-a/src/main/java/com/sbxservice/servicea/config/HttpClientConfig.java
+++ b/services/service-a/src/main/java/com/sbxservice/servicea/config/HttpClientConfig.java
@@ -1,0 +1,91 @@
+package com.sbxservice.servicea.config;
+
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class HttpClientConfig {
+
+    private final HttpClientProperties props;
+
+    public HttpClientConfig(HttpClientProperties props) {
+        this.props = props;
+    }
+
+    @Bean
+    public PoolingHttpClientConnectionManager connectionManager() {
+        ConnectionConfig connConfig = ConnectionConfig.custom()
+                .setConnectTimeout(Timeout.ofMilliseconds(props.getConnectTimeoutMs()))
+                // Default socket timeout per connection; overridden per-request by RequestConfig
+                .setSocketTimeout(Timeout.ofMilliseconds(props.getReadTimeoutMs()))
+                .build();
+
+        PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
+        cm.setMaxTotal(props.getPool().getMaxTotal());
+        cm.setDefaultMaxPerRoute(props.getPool().getMaxPerRoute());
+        cm.setDefaultConnectionConfig(connConfig);
+        // Disable connection validation before reuse. By default HC5 validates connections
+        // that have been idle for >2s — detecting a dead connection and silently opening a
+        // fresh one. Disabling this lets the stale-connection error surface as 502.
+        cm.setValidateAfterInactivity(TimeValue.ofMilliseconds(-1));
+        return cm;
+    }
+
+    @Bean
+    public CloseableHttpClient httpClient(PoolingHttpClientConnectionManager connectionManager) {
+        // Response timeout is the per-request read timeout (how long to wait for data after connection)
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setResponseTimeout(Timeout.ofMilliseconds(props.getReadTimeoutMs()))
+                .build();
+
+        // Intentionally ignore the server's Keep-Alive: timeout= header.
+        // service-b sends "Keep-Alive: timeout=5" (its Tomcat keep-alive-timeout).
+        // If we honour that, HC5 expires the pooled connection after 5s and opens a
+        // fresh one — bypassing the stale-connection error we want to demonstrate.
+        // By always returning idleTimeoutMs (30s), the pool holds the connection for
+        // 30s even though service-b already closed the TCP socket at 5s.
+        // When HC5 then tries to write on the dead socket → NoHttpResponseException → 502.
+        var keepAliveStrategy = (org.apache.hc.client5.http.ConnectionKeepAliveStrategy) (response, context) -> {
+            if (!props.getKeepAlive().isEnabled()) {
+                return TimeValue.ZERO_MILLISECONDS;
+            }
+            return TimeValue.ofMilliseconds(props.getKeepAlive().getIdleTimeoutMs());
+        };
+
+        return HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(requestConfig)
+                .setKeepAliveStrategy(keepAliveStrategy)
+                // CRITICAL: disabling auto-retry surfaces stale-connection errors as 502 Bad Gateway.
+                // Without this, Apache HttpClient silently retries on a fresh connection and the call succeeds.
+                // This is intentional for the 502 demo — remove this line to see the "fixed" behaviour.
+                .disableAutomaticRetries()
+                .build();
+    }
+
+    @Bean
+    public HttpComponentsClientHttpRequestFactory requestFactory(CloseableHttpClient httpClient) {
+        HttpComponentsClientHttpRequestFactory factory =
+                new HttpComponentsClientHttpRequestFactory(httpClient);
+        factory.setConnectTimeout(props.getConnectTimeoutMs());
+        factory.setConnectionRequestTimeout(props.getConnectTimeoutMs());
+        return factory;
+    }
+
+    @Bean
+    public RestClient restClient(HttpComponentsClientHttpRequestFactory requestFactory) {
+        return RestClient.builder()
+                .requestFactory(requestFactory)
+                .baseUrl(props.getBaseUrl())
+                .build();
+    }
+}

--- a/services/service-a/src/main/java/com/sbxservice/servicea/config/HttpClientProperties.java
+++ b/services/service-a/src/main/java/com/sbxservice/servicea/config/HttpClientProperties.java
@@ -1,0 +1,34 @@
+package com.sbxservice.servicea.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.http-client")
+public class HttpClientProperties {
+
+    private String baseUrl = "http://service-b:8082";
+    private int connectTimeoutMs = 3000;
+    private int readTimeoutMs = 5000;
+
+    private Pool pool = new Pool();
+    private KeepAlive keepAlive = new KeepAlive();
+
+    @Getter
+    @Setter
+    public static class Pool {
+        private int maxTotal = 50;
+        private int maxPerRoute = 20;
+    }
+
+    @Getter
+    @Setter
+    public static class KeepAlive {
+        private boolean enabled = true;
+        // Keep connections alive for 30s — intentionally longer than service-b's 5s keep-alive-timeout
+        // to make the 502 stale-connection scenario reproducible.
+        private int idleTimeoutMs = 30000;
+    }
+}

--- a/services/service-a/src/main/java/com/sbxservice/servicea/controller/GatewayController.java
+++ b/services/service-a/src/main/java/com/sbxservice/servicea/controller/GatewayController.java
@@ -1,0 +1,98 @@
+package com.sbxservice.servicea.controller;
+
+import com.sbxservice.servicea.config.HttpClientProperties;
+import com.sbxservice.servicea.model.GatewayResponse;
+import com.sbxservice.servicea.service.ServiceBClient;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@Tag(name = "Gateway API", description = "service-a proxies these calls to service-b — trigger 502/503/504 by varying parameters and configuration")
+public class GatewayController {
+
+    private final ServiceBClient client;
+    private final HttpClientProperties props;
+
+    public GatewayController(ServiceBClient client, HttpClientProperties props) {
+        this.client = client;
+        this.props = props;
+    }
+
+    @GetMapping("/call")
+    @Operation(
+        summary = "Happy path — calls service-b /api/data immediately",
+        description = "Returns 200 under normal conditions. " +
+                      "Returns 503 if service-b is unreachable. " +
+                      "Returns 502 if called on a stale keep-alive connection (wait 6s after a previous call)."
+    )
+    public ResponseEntity<GatewayResponse> call() {
+        long start = System.currentTimeMillis();
+        Object upstream = client.fetchData();
+        return ResponseEntity.ok(GatewayResponse.builder()
+                .status("ok")
+                .upstream(props.getBaseUrl() + "/api/data")
+                .upstreamData(upstream)
+                .gatewayTimestamp(ZonedDateTime.now())
+                .elapsedMs(System.currentTimeMillis() - start)
+                .build());
+    }
+
+    @GetMapping("/call-slow")
+    @Operation(
+        summary = "Slow call — triggers 504 when delayMs exceeds read-timeout-ms",
+        description = "Calls service-b /api/slow?delayMs={delayMs}. " +
+                      "Default delayMs=10000ms. Default read-timeout-ms=5000ms. " +
+                      "Increase delayMs beyond read-timeout-ms to trigger 504. " +
+                      "Use /api/config to see the current read-timeout-ms."
+    )
+    public ResponseEntity<GatewayResponse> callSlow(
+            @Parameter(description = "How long service-b should sleep before responding (ms)")
+            @RequestParam(defaultValue = "10000") long delayMs) {
+        long start = System.currentTimeMillis();
+        Object upstream = client.fetchSlow(delayMs);
+        return ResponseEntity.ok(GatewayResponse.builder()
+                .status("ok")
+                .upstream(props.getBaseUrl() + "/api/slow?delayMs=" + delayMs)
+                .upstreamData(upstream)
+                .gatewayTimestamp(ZonedDateTime.now())
+                .elapsedMs(System.currentTimeMillis() - start)
+                .build());
+    }
+
+    @GetMapping("/config")
+    @Operation(
+        summary = "Show current HTTP client configuration",
+        description = "Read this first to understand the active timeout and keep-alive settings before running demo scenarios."
+    )
+    public ResponseEntity<Map<String, Object>> config() {
+        return ResponseEntity.ok(Map.of(
+                "baseUrl", props.getBaseUrl(),
+                "connectTimeoutMs", props.getConnectTimeoutMs(),
+                "readTimeoutMs", props.getReadTimeoutMs(),
+                "pool", Map.of(
+                        "maxTotal", props.getPool().getMaxTotal(),
+                        "maxPerRoute", props.getPool().getMaxPerRoute()
+                ),
+                "keepAlive", Map.of(
+                        "enabled", props.getKeepAlive().isEnabled(),
+                        "idleTimeoutMs", props.getKeepAlive().getIdleTimeoutMs()
+                ),
+                "automaticRetries", "DISABLED — stale connections surface as 502 (see HttpClientConfig)",
+                "scenarios", Map.of(
+                        "504", "GET /api/call-slow?delayMs=" + (props.getReadTimeoutMs() + 5000) +
+                               "  (current read-timeout-ms=" + props.getReadTimeoutMs() + ")",
+                        "503", "Stop service-b container, then GET /api/call",
+                        "502", "GET /api/call, wait 6s, GET /api/call again " +
+                               "(service-b keep-alive=5s < service-a pool idle=" +
+                               props.getKeepAlive().getIdleTimeoutMs() + "ms)"
+                )
+        ));
+    }
+}

--- a/services/service-a/src/main/java/com/sbxservice/servicea/exception/ErrorResponse.java
+++ b/services/service-a/src/main/java/com/sbxservice/servicea/exception/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.sbxservice.servicea.exception;
+
+import lombok.*;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ErrorResponse {
+    private int httpStatus;
+    private String error;
+    private String message;
+    /** One of: TIMEOUT, UNREACHABLE, STALE_CONNECTION, UPSTREAM_ERROR */
+    private String scenario;
+    private String upstreamUrl;
+    private ZonedDateTime timestamp;
+}

--- a/services/service-a/src/main/java/com/sbxservice/servicea/exception/GlobalExceptionHandler.java
+++ b/services/service-a/src/main/java/com/sbxservice/servicea/exception/GlobalExceptionHandler.java
@@ -1,0 +1,105 @@
+package com.sbxservice.servicea.exception;
+
+import org.apache.hc.core5.http.NoHttpResponseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.time.ZonedDateTime;
+
+/**
+ * Maps upstream HTTP client exceptions to the appropriate gateway error codes.
+ *
+ * Exception → HTTP status mapping:
+ *   SocketTimeoutException       → 504 Gateway Timeout    (read timeout exceeded)
+ *   ConnectException             → 503 Service Unavailable (cannot reach service-b)
+ *   NoHttpResponseException      → 502 Bad Gateway        (stale keep-alive connection)
+ *   other ResourceAccessException → 502 Bad Gateway       (generic upstream I/O error)
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @Value("${app.http-client.base-url}")
+    private String baseUrl;
+
+    @Value("${app.http-client.read-timeout-ms}")
+    private int readTimeoutMs;
+
+    @ExceptionHandler(ResourceAccessException.class)
+    public ResponseEntity<ErrorResponse> handleResourceAccess(ResourceAccessException ex) {
+        Throwable cause = ex.getCause();
+        String causeType = cause == null ? "null" : cause.getClass().getSimpleName();
+        log.error("Upstream call to {} failed — cause: {} — {}", baseUrl, causeType, ex.getMessage());
+
+        if (cause instanceof SocketTimeoutException) {
+            return build(
+                    HttpStatus.GATEWAY_TIMEOUT,
+                    "504 Gateway Timeout",
+                    "service-b did not respond within " + readTimeoutMs + "ms. " +
+                    "Increase app.http-client.read-timeout-ms or decrease the delay in service-b's /api/slow.",
+                    "TIMEOUT"
+            );
+        }
+
+        // ConnectException (connection refused) or SocketException without "reset" in the message
+        // covers the case where the container is stopped and Docker/Colima surfaces a "System error"
+        if (cause instanceof ConnectException
+                || (cause instanceof SocketException
+                    && (cause.getMessage() == null
+                        || !cause.getMessage().toLowerCase().contains("reset")))) {
+            return build(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "503 Service Unavailable",
+                    "Could not establish a connection to service-b at " + baseUrl + ". " +
+                    "Verify the container is running and app.http-client.base-url is correct.",
+                    "UNREACHABLE"
+            );
+        }
+
+        // NoHttpResponseException: server closed the keep-alive connection before service-a reused it.
+        // Triggered when service-b's keep-alive-timeout (5s) < service-a's pool idle-timeout (30s)
+        // and automatic retries are disabled (.disableAutomaticRetries() in HttpClientConfig).
+        if (cause instanceof NoHttpResponseException
+                || (cause != null && cause.getMessage() != null
+                    && cause.getMessage().toLowerCase().contains("connection reset"))) {
+            return build(
+                    HttpStatus.BAD_GATEWAY,
+                    "502 Bad Gateway",
+                    "service-b closed the keep-alive connection before service-a could reuse it. " +
+                    "service-b's keep-alive-timeout (5s) is shorter than service-a's pool idle-timeout (30s). " +
+                    "Automatic retries are disabled intentionally — see HttpClientConfig.disableAutomaticRetries().",
+                    "STALE_CONNECTION"
+            );
+        }
+
+        return build(
+                HttpStatus.BAD_GATEWAY,
+                "502 Bad Gateway",
+                "Unexpected upstream I/O error: " + ex.getMessage(),
+                "UPSTREAM_ERROR"
+        );
+    }
+
+    private ResponseEntity<ErrorResponse> build(HttpStatus status, String error, String message, String scenario) {
+        return ResponseEntity.status(status).body(
+                ErrorResponse.builder()
+                        .httpStatus(status.value())
+                        .error(error)
+                        .message(message)
+                        .scenario(scenario)
+                        .upstreamUrl(baseUrl)
+                        .timestamp(ZonedDateTime.now())
+                        .build()
+        );
+    }
+}

--- a/services/service-a/src/main/java/com/sbxservice/servicea/model/GatewayResponse.java
+++ b/services/service-a/src/main/java/com/sbxservice/servicea/model/GatewayResponse.java
@@ -1,0 +1,19 @@
+package com.sbxservice.servicea.model;
+
+import lombok.*;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class GatewayResponse {
+    private String status;
+    private String upstream;
+    private Object upstreamData;
+    private ZonedDateTime gatewayTimestamp;
+    private long elapsedMs;
+}

--- a/services/service-a/src/main/java/com/sbxservice/servicea/service/ServiceBClient.java
+++ b/services/service-a/src/main/java/com/sbxservice/servicea/service/ServiceBClient.java
@@ -1,0 +1,41 @@
+package com.sbxservice.servicea.service;
+
+import com.sbxservice.servicea.config.HttpClientProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class ServiceBClient {
+
+    private static final Logger log = LoggerFactory.getLogger(ServiceBClient.class);
+
+    private final RestClient restClient;
+    private final HttpClientProperties props;
+
+    public ServiceBClient(RestClient restClient, HttpClientProperties props) {
+        this.restClient = restClient;
+        this.props = props;
+    }
+
+    public Object fetchData() {
+        log.debug("Calling service-b GET /api/data");
+        return restClient.get()
+                .uri("/api/data")
+                .retrieve()
+                .body(Object.class);
+    }
+
+    public Object fetchSlow(long delayMs) {
+        log.debug("Calling service-b GET /api/slow?delayMs={}", delayMs);
+        return restClient.get()
+                .uri("/api/slow?delayMs={d}", delayMs)
+                .retrieve()
+                .body(Object.class);
+    }
+
+    public String getBaseUrl() {
+        return props.getBaseUrl();
+    }
+}

--- a/services/service-a/src/main/resources/application.yml
+++ b/services/service-a/src/main/resources/application.yml
@@ -1,0 +1,62 @@
+spring:
+  application:
+    name: service-a
+  jackson:
+    serialization:
+      indent-output: true
+
+server:
+  port: 8081
+  servlet:
+    context-path: /
+  error:
+    include-message: always
+    include-binding-errors: always
+    include-stacktrace: never
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: always
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
+
+logging:
+  level:
+    root: INFO
+    com.sbxservice.servicea: DEBUG
+    # Uncomment to see Apache HttpClient wire-level logs (very verbose):
+    # org.apache.hc.client5: DEBUG
+    # org.apache.hc.core5: DEBUG
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operationsSorter: method
+    tagsSorter: alpha
+  packages-to-scan: com.sbxservice.servicea.controller
+
+app:
+  http-client:
+    base-url: "http://service-b:8082"
+    connect-timeout-ms: 3000
+    # 504 fires when service-b's response delay exceeds this value.
+    # Default: 5000ms. Override with APP_HTTP_CLIENT_READ_TIMEOUT_MS env var.
+    read-timeout-ms: 5000
+    pool:
+      max-total: 50
+      max-per-route: 20
+    keep-alive:
+      enabled: true
+      # Intentionally longer than service-b's server.tomcat.keep-alive-timeout (5s).
+      # This mismatch enables the 502 stale-connection demo.
+      idle-timeout-ms: 30000

--- a/services/service-b/Dockerfile
+++ b/services/service-b/Dockerfile
@@ -1,0 +1,24 @@
+# Build stage
+FROM maven:3.8-amazoncorretto-17 AS builder
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# Runtime stage
+FROM amazoncorretto:17-al2023-jdk
+WORKDIR /app
+RUN yum update -y && yum install -y shadow-utils && yum clean all
+RUN groupadd -r spring && useradd -r -g spring spring
+USER spring:spring
+COPY --from=builder /app/target/*.jar app.jar
+EXPOSE 8082
+HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
+  CMD curl -f http://localhost:8082/actuator/health || exit 1
+ENTRYPOINT ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "-Djava.security.egd=file:/dev/./urandom", \
+  "-jar", \
+  "app.jar"]

--- a/services/service-b/README.md
+++ b/services/service-b/README.md
@@ -1,0 +1,137 @@
+# service-b — Backend Service
+
+service-b is a simple Spring Boot 3.2 backend used as the upstream target for [service-a](../service-a/README.md). It provides endpoints that simulate different response behaviours — instant responses and configurable delays — so that service-a's HTTP client can be observed failing in different ways.
+
+---
+
+## Quick Start
+
+```bash
+# Run standalone
+cd service-b && docker compose up --build -d
+
+# Or run together with service-a (recommended for the demo)
+cd .. && docker compose up --build -d
+```
+
+---
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/data` | Returns immediately — happy path |
+| `GET` | `/api/slow?delayMs=10000` | Sleeps for `delayMs` ms before responding — triggers 504 in service-a |
+| `GET` | `/api/status` | Server info and keep-alive configuration |
+| `GET` | `/actuator/health` | Health check |
+| `GET` | `/swagger-ui.html` | Interactive API docs |
+
+---
+
+## Key Source Files
+
+### 1. `BackendController.java` — the three endpoints
+
+```
+src/main/java/com/sbxservice/serviceb/controller/BackendController.java
+```
+
+#### `/api/data` — immediate response
+
+```java
+@GetMapping("/data")
+public ResponseEntity<BackendResponse> getData() {
+    return ResponseEntity.ok(BackendResponse.builder()
+            .status("ok")
+            .message("Data returned immediately")
+            .delayMs(0)
+            .timestamp(ZonedDateTime.now())
+            .serverInstance(hostname())
+            .build());
+}
+```
+
+Used by service-a's `/api/call`. Returns instantly with no artificial delay.
+
+#### `clientPort` — connection identity indicator
+
+Every response includes `clientPort`: the ephemeral TCP source port of the caller as seen by Tomcat (`HttpServletRequest.getRemotePort()`).
+
+```java
+.clientPort(request.getRemotePort())
+```
+
+Each unique TCP connection from service-a has a unique source port assigned by the OS. When Apache HttpClient reuses a pooled connection, it reuses the same socket — and therefore the same source port. When it opens a new connection, the OS assigns a new ephemeral port.
+
+```
+Call 1 → clientPort: 57498   (new connection, OS assigned port)
+Call 2 → clientPort: 57498   (same port = same TCP connection reused)
+wait 7s (service-b closes socket at 5s)
+Call 3 → 502                 (service-a tries port 57498 again, but server already closed it)
+```
+
+This makes connection reuse directly observable without any external tooling.
+
+#### `/api/slow` — configurable delay
+
+```java
+@GetMapping("/slow")
+public ResponseEntity<BackendResponse> getSlow(
+        @RequestParam(defaultValue = "10000") long delayMs) throws InterruptedException {
+    Thread.sleep(delayMs);
+    return ResponseEntity.ok(...);
+}
+```
+
+`Thread.sleep(delayMs)` holds the HTTP connection open for `delayMs` milliseconds before sending any response byte. service-a's read timeout clock starts ticking the moment the TCP connection is established — so if `delayMs` exceeds service-a's `read-timeout-ms` (default 5000ms), service-a's `SocketTimeoutException` fires and it returns 504 to the client.
+
+**Why `Thread.sleep` and not a non-blocking delay?**
+`Thread.sleep` is intentionally blocking — it ties up the Tomcat worker thread and keeps the socket open without writing any data. This is the correct simulation of a slow upstream: the connection is accepted but the response is withheld.
+
+---
+
+### 2. `application.yml` — the keep-alive timeout setting
+
+```
+src/main/resources/application.yml
+```
+
+```yaml
+server:
+  tomcat:
+    keep-alive-timeout: 5000   # close idle HTTP/1.1 connections after 5s
+```
+
+This is the **most important configuration line** in service-b for the demo. When a request completes, Tomcat includes `Keep-Alive: timeout=5` in the response headers and keeps the TCP socket open for up to 5 seconds waiting for the next request. After 5 seconds of inactivity, Tomcat closes the socket with a TCP `FIN`.
+
+**The mismatch this creates:**
+
+```
+service-b closes idle socket after:   5s   (this file)
+service-a pool holds connection for:  30s  (service-a application.yml)
+```
+
+service-a does not honour service-b's `Keep-Alive: timeout=5` header — it keeps the connection in its pool for the full 30 seconds. After 5 seconds, service-b has sent `FIN` and closed its end. When service-a tries to write on that socket at second 7, it gets `NoHttpResponseException` → **502 Bad Gateway**.
+
+To make the mismatch visible vs. hidden:
+
+| `keep-alive-timeout` in service-b | Result |
+|-----------------------------------|--------|
+| 5000ms (current) | Server closes socket before client retires it → 502 possible |
+| 30000ms or more | Server and client agree → no stale connection → 502 never happens |
+
+---
+
+## Response Format
+
+```json
+{
+  "status": "ok",
+  "message": "Data returned immediately",
+  "delayMs": 0,
+  "timestamp": "2026-06-04T16:00:00Z",
+  "serverInstance": "a1b2c3d4e5f6"
+}
+```
+
+`serverInstance` is the container hostname — useful when running multiple replicas to see which instance responded.

--- a/services/service-b/docker-compose.yml
+++ b/services/service-b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  service-b:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: service-b
+    ports:
+      - "8082:8082"
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - JAVA_OPTS=-Xmx512m -Xms256m
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8082/actuator/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 20s
+    networks:
+      - sbxservice-network
+
+networks:
+  sbxservice-network:
+    driver: bridge

--- a/services/service-b/pom.xml
+++ b/services/service-b/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.3</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.sbxservice</groupId>
+    <artifactId>service-b</artifactId>
+    <version>0.1.0</version>
+    <name>service-b</name>
+    <description>Backend service for HTTP 502/503/504 error scenario demonstrations</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
+        <jacoco.version>0.8.11</jacoco.version>
+        <lombok.version>1.18.30</lombok.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc-openapi.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                    <image>
+                        <name>sbxservice/${project.artifactId}:${project.version}</name>
+                    </image>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/services/service-b/src/main/java/com/sbxservice/serviceb/ServiceBApplication.java
+++ b/services/service-b/src/main/java/com/sbxservice/serviceb/ServiceBApplication.java
@@ -1,0 +1,12 @@
+package com.sbxservice.serviceb;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ServiceBApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ServiceBApplication.class, args);
+    }
+}

--- a/services/service-b/src/main/java/com/sbxservice/serviceb/controller/BackendController.java
+++ b/services/service-b/src/main/java/com/sbxservice/serviceb/controller/BackendController.java
@@ -1,0 +1,97 @@
+package com.sbxservice.serviceb.controller;
+
+import com.sbxservice.serviceb.model.BackendResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.net.InetAddress;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@Tag(name = "Backend API", description = "service-b endpoints — used by service-a to demonstrate 502/503/504 error scenarios")
+public class BackendController {
+
+    private static final Logger log = LoggerFactory.getLogger(BackendController.class);
+
+    @Value("${server.tomcat.keep-alive-timeout:60000}")
+    private long keepAliveTimeoutMs;
+
+    @GetMapping("/data")
+    @Operation(summary = "Immediate response — happy path")
+    public ResponseEntity<BackendResponse> getData(HttpServletRequest request) {
+        log.debug("Returning immediate data response, clientPort={}", request.getRemotePort());
+        return ResponseEntity.ok(BackendResponse.builder()
+                .status("ok")
+                .message("Data returned immediately")
+                .delayMs(0)
+                .timestamp(ZonedDateTime.now())
+                .serverInstance(hostname())
+                .clientPort(request.getRemotePort())
+                .build());
+    }
+
+    @GetMapping("/slow")
+    @Operation(
+        summary = "Delayed response — triggers 504 in service-a when delayMs > service-a's read-timeout-ms",
+        description = "Sleeps for the specified duration before responding. " +
+                      "Set delayMs greater than service-a's app.http-client.read-timeout-ms (default 5000) to trigger 504."
+    )
+    public ResponseEntity<BackendResponse> getSlow(
+            @Parameter(description = "How long to sleep in milliseconds before responding")
+            @RequestParam(defaultValue = "10000") long delayMs,
+            HttpServletRequest request) throws InterruptedException {
+        log.info("Sleeping for {}ms, clientPort={}", delayMs, request.getRemotePort());
+        Thread.sleep(delayMs);
+        log.info("Woke up after {}ms, returning response", delayMs);
+        return ResponseEntity.ok(BackendResponse.builder()
+                .status("slow-ok")
+                .message("Responded after " + delayMs + "ms delay")
+                .delayMs(delayMs)
+                .timestamp(ZonedDateTime.now())
+                .serverInstance(hostname())
+                .clientPort(request.getRemotePort())
+                .build());
+    }
+
+    @GetMapping("/status")
+    @Operation(
+        summary = "Server status and keep-alive info",
+        description = "Shows server info and the configured keep-alive-timeout. " +
+                      "This value is intentionally shorter than service-a's pool idle-timeout to enable the 502 stale-connection demo."
+    )
+    public ResponseEntity<Map<String, Object>> getStatus() {
+        Runtime rt = Runtime.getRuntime();
+        return ResponseEntity.ok(Map.of(
+                "service", "service-b",
+                "instance", hostname(),
+                "timestamp", ZonedDateTime.now().toString(),
+                "keepAliveTimeoutMs", keepAliveTimeoutMs,
+                "jvm", Map.of(
+                        "freeMemoryMb", rt.freeMemory() / (1024 * 1024),
+                        "totalMemoryMb", rt.totalMemory() / (1024 * 1024)
+                ),
+                "demo502Note", "Tomcat keep-alive-timeout=" + keepAliveTimeoutMs +
+                        "ms. service-a pool idle-timeout=30000ms. " +
+                        "Wait " + (keepAliveTimeoutMs / 1000 + 1) +
+                        "s between calls to trigger 502 in service-a."
+        ));
+    }
+
+    private String hostname() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+}

--- a/services/service-b/src/main/java/com/sbxservice/serviceb/model/BackendResponse.java
+++ b/services/service-b/src/main/java/com/sbxservice/serviceb/model/BackendResponse.java
@@ -1,0 +1,23 @@
+package com.sbxservice.serviceb.model;
+
+import lombok.*;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class BackendResponse {
+    private String status;
+    private String message;
+    private long delayMs;
+    private ZonedDateTime timestamp;
+    private String serverInstance;
+    // The ephemeral TCP source port of the caller (service-a's outgoing port).
+    // Same port across two requests = same TCP connection was reused.
+    // Different port = Apache HttpClient opened a new connection.
+    private int clientPort;
+}

--- a/services/service-b/src/main/resources/application.yml
+++ b/services/service-b/src/main/resources/application.yml
@@ -1,0 +1,48 @@
+spring:
+  application:
+    name: service-b
+  jackson:
+    serialization:
+      indent-output: true
+
+server:
+  port: 8082
+  servlet:
+    context-path: /
+  error:
+    include-message: always
+    include-binding-errors: always
+    include-stacktrace: never
+  tomcat:
+    # KEY for 502 demo: Tomcat closes idle keep-alive connections after 5s.
+    # service-a's connection pool holds connections for 30s (keep-alive.idle-timeout-ms: 30000).
+    # When service-a reuses a connection that Tomcat already closed → 502 Bad Gateway.
+    keep-alive-timeout: 5000
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: always
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
+
+logging:
+  level:
+    root: INFO
+    com.sbxservice.serviceb: DEBUG
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operationsSorter: method
+    tagsSorter: alpha
+  packages-to-scan: com.sbxservice.serviceb.controller


### PR DESCRIPTION
## Summary

- **service-a** (port 8081): Spring Boot gateway using Apache HttpClient 5 with configurable timeouts, keep-alive pool, and intentional mismatches that reproduce 502/503/504 errors without any code changes — all settings are overridable via environment variables
- **service-b** (port 8082): Backend with `/api/data` (immediate) and `/api/slow?delayMs=N` (configurable delay) endpoints; Tomcat `keep-alive-timeout` set to 5s to enable the 502 stale-connection scenario; every response includes `clientPort` so TCP connection reuse is directly observable
- **Shared `docker-compose.yml`**: orchestrates both services on a shared network with `depends_on: service_healthy`
- **`DEMO-HANDBOOK.md`**: full demo guide covering all three error scenarios, configuration reference, prevention best practices (5 rules), and HC5 pool borrowing strategy (LIFO, sequential vs concurrent, pool sizing formula)
- **READMEs** for service-a and service-b explaining key source files and design decisions

## Error scenarios demonstrated

| Error | How to trigger | Root cause |
|-------|---------------|------------|
| 504 Gateway Timeout | `GET /api/call-slow?delayMs=10000` | `SocketTimeoutException` after read-timeout-ms (5s) |
| 503 Service Unavailable | Stop service-b container | `ConnectException` — connection refused |
| 502 Bad Gateway | Call, wait 6s, call again | `NoHttpResponseException` — stale keep-alive connection reused with retries disabled |

## Test plan

- [ ] `docker compose up --build -d` from `services/` — both containers reach `(healthy)`
- [ ] `curl http://localhost:8081/api/call` returns 200 with `clientPort` in `upstreamData`
- [ ] Two immediate calls return the same `clientPort` (connection reused)
- [ ] `curl "http://localhost:8081/api/call-slow?delayMs=10000"` returns 504 after ~5s
- [ ] `docker compose stop service-b && curl http://localhost:8081/api/call` returns 503
- [ ] Call, `sleep 6`, call again returns 502 with `scenario: STALE_CONNECTION`

🤖 Generated with [Claude Code](https://claude.com/claude-code)